### PR TITLE
Add decimal and negative support for GCD

### DIFF
--- a/docs/GCD/index.md
+++ b/docs/GCD/index.md
@@ -1,5 +1,5 @@
 # GCD
-The `M.gcd()` function returns the gcd of two or more numbers.
+The `M.gcd()` function returns the gcd of two or more numbers. If one or both numbers is negative, the result will still be positive. If one or both numbers are decimals, the gcd will be returned to a maximum of 10 decimal places, however both numbers cannot have more than 16 digits.
 
 ### Syntax
 > M.gcd([value1, value2, ...])
@@ -13,16 +13,19 @@ The `M.gcd()` function returns the gcd of two or more numbers.
 ### Examples
 - Valid:
 	```js
-	M.gcd([12, 18, 24]);   // 6
-	M.gcd([8, 7]);         // 1
+	M.gcd([12, 18, 24]);   					// 6
+	M.gcd([8, 7]);         					// 1
+	M.gcd(-20, 24);		   					// 4
+	M.gcd([1.1, 5.5]); 	   					// 1.1
+	M.gcd([923.2398423, 9497853.2249])		//0.0000001
 	```
 - Invalid:
 	```js
 	/*
 	 * TypeError: Invalid argument received: <argument>
-	 * 'gcd()' only accept an array of positive real numbers!
+	 * 'gcd()' only accept an array of real numbers!
 	 */
-	M.gcd(-20, 24);
+	
 	M.gcd([NaN, 5, Infinity]);
 	M.gcd(['foo', 'bar']);
 	```

--- a/src/gcd/index.js
+++ b/src/gcd/index.js
@@ -1,12 +1,30 @@
 /* Function: gcd() */
 
-const validate = require('../validation/integer-array');
+const validate = require('../validation/number-array');
 
 function gcd(a, b) {
-  return (a == 0) ? b : gcd(b % a, a);
+	return (a == 0) ? b : gcd(b % a, a);
 }
+
+const getDecimalCount = value => {
+	var decimals = 0;
+	if (value % 1 === 0) {
+		return decimals;
+	}
+	decimals++;
+	for (var i = 1; i < 11; i++) {
+		if ((value * Math.pow(10, i)) % 1 !== 0) {
+			decimals++;
+		}
+		else { break; }
+	}
+	return decimals;
+};
 
 module.exports = arr => {
 	validate(arr, 'gcd');
-	return arr.reduce((prev, next) =>  gcd(prev, next), arr[0]);
+	var posArr = arr.map((value) => (value < 0) ? value * -1 : value);
+	var largestDecimal = posArr.reduce((prev, next) => Math.max(getDecimalCount(prev), getDecimalCount(next)));
+	return posArr.reduce((prev, next) => gcd(prev * Math.pow(10, largestDecimal), next * Math.pow(10, largestDecimal)) / Math.pow(10, largestDecimal), posArr[0]);
 };
+

--- a/src/inverse/index.js
+++ b/src/inverse/index.js
@@ -2,7 +2,7 @@
 * function : modInv()
 */
 
-const validate = require('../validation/integer');
+const validate = require('../validation/positive-integer');
 
 const gcd = require('../gcd');
 

--- a/test/gcd-spec.js
+++ b/test/gcd-spec.js
@@ -19,6 +19,18 @@ describe('[Function: gcd]', () => {
 		assert.strictEqual(gcd([24, 28]), 4);
 	});
 
+	it('should return \'1.1\' when \'[1.1, 5.5]\' is passed', () => {
+		assert.strictEqual(gcd([1.1, 5.5]), 1.1);
+	});
+
+	it('should return \'0.0000001\' when \'[923.2398423, 9497853.2249]\' is passed', () => {
+		assert.strictEqual(gcd([923.2398423, 9497853.2249]), 0.0000001);
+	});
+
+	it('should return \'2\' when \'[-8, 6] is passed\'', () => {
+		assert.strictEqual(gcd([-8, 6]), 2);
+	});
+
 	it('should throw an error when a negative number is passed', () => {
 		assert.throws(() => gcd(-20), TypeError);
 	});


### PR DESCRIPTION
Adds support for M.gcd() to evaluate the gcd of numbers with decimals and numbers less than 0.

### Do the checklist before submitting the PR:

- [X] Have you read the guidelines mentioned in **CONTRIBUTING.md**?
- [X] Have you squashed your commits?

**Q**: What version of *Node.js* you've used in the project? (`e.g. Node v10.11.0`)
**A**: Node v12.4.0

**Q**: Mention the *Issue Number*! (`e.g. Fixed #8`)
**A**: Fixed #215 and added extra feature

- *Give additional information regarding the PR below:*
Implements feature requested in #215, as well as adding support to return gcd of negative numbers, returning the gcd as a positive number.
------------