### PR TITLE
(docs): fixed small errors

### DIFF
--- a/docs/Euler's Totient/index.md
+++ b/docs/Euler's Totient/index.md
@@ -18,17 +18,17 @@ The ``` M.phi() ``` function for an input n returns count of numbers in {1, 2, 3
 	M.phi(10)                                // 4 
 	```  
 - Invalid:  
-	```js
-	/*
-	 * TypeError: Invalid argument received: <argument>
-	 * 'phi()' only accept a non-negative-integer!
-	 */
-	M.phi("31")
-	M.phi(true)
-  M.phi(31.101996)
-  M.phi(-20)
-  M.phi(0)
-	```
+
+```js
+/*
+ * TypeError: Invalid argument received: <argument>
+ * 'phi()' only accept a non-negative-integer!
+ */
+M.phi("31")
+M.phi(true)
+M.phi(31.101996)
+M.phi(-20)
+```
 
 ### Info:
 Implemented using Euler’s product formula.


### PR DESCRIPTION
I fixed the formatting and removed `M.phi(0)` from invalid section, because it's valid above